### PR TITLE
Settings: Add refresh rate preferences

### DIFF
--- a/res/values/custom_config.xml
+++ b/res/values/custom_config.xml
@@ -39,4 +39,7 @@
     <string name="adaptive_playback_timeout_10_min">10 minutes</string>
     <string name="adaptive_playback_timeout_10_min_summary">On (10 minutes)</string>
 
+
+    <!-- Whether to show min / max refresh rate preference in display settings -->
+    <bool name="config_show_refresh_rate_controls">false</bool>
 </resources>

--- a/res/values/custom_strings.xml
+++ b/res/values/custom_strings.xml
@@ -74,4 +74,9 @@
     <!-- Smart 5G -->
     <string name="smart_5g_title">Smart 5G</string>
     <string name="smart_5g_summary">Automatically switch between 5G and 4G to reduce battery consumption</string>
+
+    <!-- Min / max refresh rate -->
+    <string name="min_refresh_rate_title">Minimum refresh rate</string>
+    <string name="max_refresh_rate_title">Maximum refresh rate</string>
+    <string name="refresh_rate_placeholder"><xliff:g id="refresh_rate" example="60">%1$s</xliff:g> Hz</string>
 </resources>

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -116,6 +116,16 @@
             android:summary="@string/force_high_refresh_rate_desc"
             settings:controller="com.android.settings.display.ForcePeakRefreshRatePreferenceController"/>
 
+        <ListPreference
+            android:key="min_refresh_rate"
+            android:title="@string/min_refresh_rate_title"
+            android:summary="@string/summary_placeholder" />
+        
+        <ListPreference
+            android:key="max_refresh_rate"
+            android:title="@string/max_refresh_rate_title"
+            android:summary="@string/summary_placeholder" />
+        
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/src/com/android/settings/DisplaySettings.java
+++ b/src/com/android/settings/DisplaySettings.java
@@ -24,6 +24,8 @@ import com.android.settings.dashboard.DashboardFragment;
 import com.android.settings.display.BrightnessLevelPreferenceController;
 import com.android.settings.display.CameraGesturePreferenceController;
 import com.android.settings.display.LiftToWakePreferenceController;
+import com.android.settings.display.MaxRefreshRatePreferenceController;
+import com.android.settings.display.MinRefreshRatePreferenceController;
 import com.android.settings.display.ShowOperatorNamePreferenceController;
 import com.android.settings.display.TapToWakePreferenceController;
 import com.android.settings.display.ThemePreferenceController;
@@ -80,6 +82,8 @@ public class DisplaySettings extends DashboardFragment {
         controllers.add(new ShowOperatorNamePreferenceController(context));
         controllers.add(new ThemePreferenceController(context));
         controllers.add(new BrightnessLevelPreferenceController(context, lifecycle));
+        controllers.add(new MinRefreshRatePreferenceController(context, lifecycle));
+        controllers.add(new MaxRefreshRatePreferenceController(context, lifecycle));
         return controllers;
     }
 

--- a/src/com/android/settings/display/MaxRefreshRatePreferenceController.kt
+++ b/src/com/android/settings/display/MaxRefreshRatePreferenceController.kt
@@ -1,0 +1,233 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ * Copyright (C) 2021 The LineageOS Project
+ * Copyright (C) 2022 AOSP-Krypton Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.display
+
+import android.content.Context
+import android.database.ContentObserver
+import android.hardware.display.DisplayManager
+import android.os.Handler
+import android.os.UserHandle
+import android.provider.DeviceConfig
+import android.provider.Settings
+import android.util.Log
+import android.view.Display
+
+import androidx.lifecycle.Lifecycle.Event
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.preference.ListPreference
+import androidx.preference.Preference
+import androidx.preference.PreferenceScreen
+
+import com.android.settings.R
+import com.android.settings.core.BasePreferenceController
+import com.android.settingslib.core.lifecycle.Lifecycle
+
+class MaxRefreshRatePreferenceController(
+    context: Context,
+    lifecycle: Lifecycle?,
+) : BasePreferenceController(context, KEY),
+    LifecycleEventObserver,
+    Preference.OnPreferenceChangeListener {
+
+    private val handler = Handler(context.mainLooper)
+    private val deviceConfigObserver = DeviceConfigObserver()
+    private val settingsObserver = object : ContentObserver(handler) {
+        override fun onChange(selfChange: Boolean) {
+            listPreference?.let { updateState(it) }
+        }
+    }
+
+    private var listPreference: ListPreference? = null
+
+    private var defaultPeakRefreshRate = getDefaultPeakRefreshRate()
+    private val values: List<Float>
+
+    init {
+        val display: Display? = context.getSystemService(
+            DisplayManager::class.java
+        ).getDisplay(Display.DEFAULT_DISPLAY)
+
+        val tmpValues = mutableListOf<Float>()
+        if (display == null) {
+            Log.e(TAG, "No valid default display device")
+        } else {
+            val mode = display.mode
+            display.supportedModes.forEach {
+                if (it.physicalWidth == mode.physicalWidth &&
+                        it.physicalHeight == mode.physicalHeight
+                ) {
+                    val refreshRate = refreshRateRegex.find(
+                        it.refreshRate.toString()
+                    )?.value?.toFloat() ?: return@forEach
+                    if (!tmpValues.contains(refreshRate)) {
+                        tmpValues.add(refreshRate)
+                    }
+                }
+            }
+        }
+        values = tmpValues.sorted()
+
+        lifecycle?.addObserver(this)
+    }
+
+    private fun getDefaultPeakRefreshRate(): Float {
+        val peakRefreshRate = DeviceConfig.getFloat(
+            DeviceConfig.NAMESPACE_DISPLAY_MANAGER,
+            DisplayManager.DeviceConfig.KEY_PEAK_REFRESH_RATE_DEFAULT,
+            INVALID_REFRESH_RATE
+        )
+        return if (peakRefreshRate == INVALID_REFRESH_RATE) {
+            mContext.resources.getInteger(
+                com.android.internal.R.integer.config_defaultPeakRefreshRate
+            ).toFloat()
+        } else {
+            peakRefreshRate
+        }
+    }
+
+    override fun displayPreference(screen: PreferenceScreen) {
+        super.displayPreference(screen)
+        listPreference = screen.findPreference(KEY)
+    }
+
+    override fun getAvailabilityStatus(): Int =
+        if (mContext.resources.getBoolean(R.bool.config_show_refresh_rate_controls)
+                && values.size > 1
+        ) {
+            AVAILABLE
+        } else {
+            UNSUPPORTED_ON_DEVICE
+        }
+
+    override fun updateState(preference: Preference) {
+        val currentValue = Settings.System.getFloatForUser(
+            mContext.contentResolver,
+            Settings.System.PEAK_REFRESH_RATE,
+            defaultPeakRefreshRate,
+            UserHandle.USER_CURRENT
+        )
+        updateStateInternal(currentValue)
+    }
+
+    private fun updateStateInternal(currentValue: Float) {
+        val minRate = Settings.System.getFloatForUser(
+            mContext.contentResolver,
+            Settings.System.MIN_REFRESH_RATE,
+            DEFAULT_REFRESH_RATE,
+            UserHandle.USER_CURRENT
+        )
+        listPreference?.let { preference ->
+            preference.setEnabled(minRate <= currentValue)
+
+            // There is no point in setting max refresh rate
+            // below minimum refresh rate. So show only rates
+            // greater than minimum rate.
+            val restrictedValues = values.filter {
+                it >= minRate
+            }.map {
+                it.toInt().toString()
+            }
+            preference.entryValues = restrictedValues.toTypedArray()
+            preference.entries = restrictedValues.map {
+                mContext.getString(R.string.refresh_rate_placeholder, it)
+            }.toTypedArray()
+
+            val refreshRate = currentValue.toInt().toString()
+            val index = preference.findIndexOfValue(refreshRate)
+            if (index != -1) {
+                preference.setValueIndex(index)
+            }
+            // Show actual value as summary irrespective of whether it is
+            // present in entries or not.
+            preference.summary = mContext.getString(
+                R.string.refresh_rate_placeholder,
+                refreshRate
+            )
+        }
+    }
+
+    override fun onStateChanged(owner: LifecycleOwner, event: Event) {
+        if (event == Event.ON_START) {
+            deviceConfigObserver.startListening()
+            with (mContext.contentResolver) {
+                registerContentObserver(
+                    Settings.System.getUriFor(Settings.System.MIN_REFRESH_RATE),
+                    false,
+                    settingsObserver,
+                    UserHandle.USER_CURRENT
+                )
+                registerContentObserver(
+                    Settings.System.getUriFor(Settings.System.PEAK_REFRESH_RATE),
+                    false,
+                    settingsObserver,
+                    UserHandle.USER_CURRENT
+                )
+            }
+        } else if (event == Event.ON_STOP) {
+            mContext.contentResolver.unregisterContentObserver(settingsObserver)
+            deviceConfigObserver.stopListening()
+        }
+    }
+
+    override fun onPreferenceChange(preference: Preference, newValue: Any): Boolean {
+        // ContentObserver will update the preference
+        return Settings.System.putFloatForUser(
+            mContext.contentResolver,
+            Settings.System.PEAK_REFRESH_RATE,
+            (newValue as String).toFloat(),
+            UserHandle.USER_CURRENT
+        )
+    }
+
+    private inner class DeviceConfigObserver :
+        DeviceConfig.OnPropertiesChangedListener {
+
+        fun startListening() {
+            DeviceConfig.addOnPropertiesChangedListener(
+                DeviceConfig.NAMESPACE_DISPLAY_MANAGER,
+                {
+                    handler.post(it)
+                } /* Executor */,
+                this /* Listener */)
+        }
+
+        fun stopListening() {
+            DeviceConfig.removeOnPropertiesChangedListener(this)
+        }
+
+        override fun onPropertiesChanged(properties: DeviceConfig.Properties) {
+            // Got notified if any property has been changed in NAMESPACE_DISPLAY_MANAGER. The
+            // KEY_PEAK_REFRESH_RATE_DEFAULT value could be added, changed, removed or unchanged.
+            // Just force a UI update for any case.
+            defaultPeakRefreshRate = getDefaultPeakRefreshRate()
+            listPreference?.let { updateState(it) }
+        }
+    }
+
+    companion object {
+        private const val KEY = "max_refresh_rate"
+        private const val TAG = "MaxRefreshRatePC"
+
+        private val refreshRateRegex = Regex("[0-9]+")
+
+        private const val INVALID_REFRESH_RATE = -1f
+        private const val DEFAULT_REFRESH_RATE = 60f
+    }
+}

--- a/src/com/android/settings/display/MinRefreshRatePreferenceController.kt
+++ b/src/com/android/settings/display/MinRefreshRatePreferenceController.kt
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2020 The LineageOS Project
+ * Copyright (C) 2022 AOSP-Krypton Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.display
+
+import android.content.Context
+import android.database.ContentObserver
+import android.hardware.display.DisplayManager
+import android.os.Handler
+import android.os.UserHandle
+import android.provider.Settings
+import android.util.Log
+import android.view.Display
+
+import androidx.lifecycle.Lifecycle.Event
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.preference.ListPreference
+import androidx.preference.Preference
+import androidx.preference.PreferenceScreen
+
+import com.android.settings.R
+import com.android.settings.core.BasePreferenceController
+import com.android.settingslib.core.lifecycle.Lifecycle
+
+class MinRefreshRatePreferenceController(
+    context: Context,
+    lifecycle: Lifecycle?,
+) : BasePreferenceController(context, KEY),
+    LifecycleEventObserver,
+    Preference.OnPreferenceChangeListener {
+
+    private val handler = Handler(context.mainLooper)
+    private val settingsObserver = object : ContentObserver(handler) {
+        override fun onChange(selfChange: Boolean) {
+            listPreference?.let { updateState(it) }
+        }
+    }
+
+    private var listPreference: ListPreference? = null
+
+    private val entries: Array<String>
+    private val values: Array<String>
+
+    init {
+        val display: Display? = context.getSystemService(
+            DisplayManager::class.java
+        ).getDisplay(Display.DEFAULT_DISPLAY)
+
+        val tmpValues = mutableListOf<Int>()
+        if (display == null) {
+            Log.e(TAG, "No valid default display device")
+        } else {
+            val mode = display.mode
+            display.supportedModes.forEach {
+                if (it.physicalWidth == mode.physicalWidth &&
+                        it.physicalHeight == mode.physicalHeight
+                ) {
+                    val refreshRate = refreshRateRegex.find(
+                        it.refreshRate.toString()
+                    )?.value?.toInt() ?: return@forEach
+                    if (!tmpValues.contains(refreshRate)) {
+                        tmpValues.add(refreshRate)
+                    }
+                }
+            }
+        }
+        val sortedList = tmpValues.sorted()
+        entries = sortedList.map {
+            context.getString(R.string.refresh_rate_placeholder, it)
+        }.toTypedArray()
+        values = sortedList.map { it.toString() }.toTypedArray()
+
+        lifecycle?.addObserver(this)
+    }
+
+    override fun displayPreference(screen: PreferenceScreen) {
+        super.displayPreference(screen)
+        listPreference = screen.findPreference<ListPreference>(KEY)?.also {
+            it.entries = entries
+            it.entryValues = values
+        }
+    }
+
+    override fun getAvailabilityStatus(): Int =
+        if (mContext.resources.getBoolean(R.bool.config_show_refresh_rate_controls)
+                && entries.size > 1
+        ) {
+            AVAILABLE
+        } else {
+            UNSUPPORTED_ON_DEVICE
+        }
+
+    override fun updateState(preference: Preference) {
+        val currentValue = Settings.System.getFloatForUser(
+            mContext.contentResolver,
+            Settings.System.MIN_REFRESH_RATE,
+            DEFAULT_REFRESH_RATE,
+            UserHandle.USER_CURRENT
+        )
+        updateStateInternal(
+            if (currentValue == NO_CONFIG)
+                DEFAULT_REFRESH_RATE
+            else
+                currentValue
+        )
+    }
+
+    private fun updateStateInternal(currentValue: Float) {
+        listPreference?.let {
+            val refreshRate = currentValue.toInt().toString()
+            val index = it.findIndexOfValue(refreshRate)
+            if (index > -1) {
+                it.setValueIndex(index)
+            }
+            // Show actual value as summary irrespective of whether it is
+            // present in entries or not.
+            it.summary = mContext.getString(
+                R.string.refresh_rate_placeholder, refreshRate)
+        }
+    }
+
+    override fun onStateChanged(owner: LifecycleOwner, event: Event) {
+        if (event == Event.ON_START) {
+            mContext.contentResolver.registerContentObserver(
+                Settings.System.getUriFor(Settings.System.MIN_REFRESH_RATE),
+                false,
+                settingsObserver,
+                UserHandle.USER_CURRENT
+            )
+        } else if (event == Event.ON_STOP) {
+            mContext.contentResolver.unregisterContentObserver(settingsObserver)
+        }
+    }
+
+    override fun onPreferenceChange(preference: Preference, newValue: Any): Boolean {
+        val refreshRate = (newValue as String).toFloat()
+        val changed = Settings.System.putFloatForUser(
+            mContext.contentResolver,
+            Settings.System.MIN_REFRESH_RATE,
+            refreshRate,
+            UserHandle.USER_CURRENT
+        )
+        if (changed) {
+            updateStateInternal(refreshRate)
+        }
+        return changed
+    }
+
+    companion object {
+        private const val KEY = "min_refresh_rate"
+        private const val TAG = "MinRefreshRatePC"
+
+        private val refreshRateRegex = Regex("[0-9]+")
+
+        private const val INVALID_REFRESH_RATE = -1f
+        private const val NO_CONFIG = 0f
+        private const val DEFAULT_REFRESH_RATE = 60f
+    }
+}


### PR DESCRIPTION
Settings: Add preference for KEY_MIN_REFRESH_RATE

Change-Id: Iac1f65ab09717ea55a5b471e094385c77ba894ee



Settings: Add peak refresh rate list preference

* AOSP 'Smooth display' setting is just a toggle, some devices support multiple refresh rates so add support for it with a ListPreference.

* @jhonboy121: unify config flag for both min and max list preference

Change-Id: I3da3d2b86e61ed3caf9af5770d8bdb4485817b97


Settings: Rewrite refresh rate preference controllers in kt and improve

* Added settings observer to update preference on settings changes. We have a tile so it would be nice to reflect changes when tile state is changed.
* Restrict max refresh rate list based on the min rate set since it is absurd to allow setting max values below current min rate.




Settings: Display 60 as min refresh rate if key value is 0



Settings: Fix refresh rate list preference values order

* basically just sort it before adding to list, apparently the order was not ascending for vayu




Settings: Update config for refresh rate